### PR TITLE
Correction of unidiomatic case in title string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# test-repo
+# Test-Repo


### PR DESCRIPTION
In this pull request, I corrected the unidiomatic case in the title string "test-repo" (standardised to "Test-Repo")